### PR TITLE
net-im/pidgin: add libgnome-keyring dep for gnome-keyring-1.pc and libgnome-keyring.so.0

### DIFF
--- a/net-im/pidgin/pidgin-2.12.0.ebuild
+++ b/net-im/pidgin/pidgin-2.12.0.ebuild
@@ -80,7 +80,7 @@ RDEPEND="
 	# Mono support crashes pidgin
 	#mono? ( dev-lang/mono )"
 
-RDEPEND+=" gnome-keyring? ( gnome-base/gnome-keyring )"
+RDEPEND+=" gnome-keyring? ( gnome-base/gnome-keyring gnome-base/libgnome-keyring:= )"
 
 # We want nls in case gtk is enabled, bug #
 NLS_DEPEND=">=dev-util/intltool-0.41.1 sys-devel/gettext"


### PR DESCRIPTION
Fixes pkg-config failure locating gnome-keyring-1.pc in	src_configure.

@chutz